### PR TITLE
updated url to redirected url

### DIFF
--- a/scripts/fruster-install-nats
+++ b/scripts/fruster-install-nats
@@ -59,7 +59,7 @@ installNats() {
   	read -p "Choose namespace for NATS, this should be something related to a project and will be used as part of internal DNS name to access NATS later on (example 'paceup'): " NATS_NAMESPACE	
   fi
 
-  helm install https://github.com/FrostDigital/nats-helm-chart/archive/master.tar.gz --name ${HELM_DEPLOYMENT_NAME} --namespace ${NATS_NAMESPACE} --set replicas=${NUM_REPLICAS:-3}
+  helm install https://codeload.github.com/FrostDigital/nats-helm-chart/tar.gz/master --name ${HELM_DEPLOYMENT_NAME} --namespace ${NATS_NAMESPACE} --set replicas=${NUM_REPLICAS:-3}
 
   log_success "NATS is installed and accesible on nats.${NATS_NAMESPACE}:4222"
 }


### PR DESCRIPTION
Running **fruster-install-nats** gives `Error: file "https://github.com/FrostDigital/nats-helm-chart/archive/master.tar.gz" not found`

So I am using the redirected url curl gives me for the download instead to see if that will work (it does with curl when using the redirect url, so let's see)

<img width="1017" alt="screen shot 2018-11-27 at 06 00 42" src="https://user-images.githubusercontent.com/3381883/49059654-3229e000-f20a-11e8-962b-1532cfc18f0b.png">


@joelso  will merge this myself now in order to test but will revert back if it doesn't


