### PR TITLE
[FIX] curl downloads helm chart

### DIFF
--- a/scripts/fruster-install-nats
+++ b/scripts/fruster-install-nats
@@ -59,7 +59,8 @@ installNats() {
   	read -p "Choose namespace for NATS, this should be something related to a project and will be used as part of internal DNS name to access NATS later on (example 'paceup'): " NATS_NAMESPACE	
   fi
 
-  helm install https://github.com/FrostDigital/nats-helm-chart/archive/master.tar.gz --name ${HELM_DEPLOYMENT_NAME} --namespace ${NATS_NAMESPACE} --set replicas=${NUM_REPLICAS:-3}
+	curl -L https://github.com/FrostDigital/nats-helm-chart/archive/master.tar.gz --output /tmp/nats-helm-chart.tar.gz
+  helm install /tmp/nats-helm-chart.tar.gz --name ${HELM_DEPLOYMENT_NAME} --namespace ${NATS_NAMESPACE} --set replicas=${NUM_REPLICAS:-3}
 
   log_success "NATS is installed and accesible on nats.${NATS_NAMESPACE}:4222"
 }


### PR DESCRIPTION
Curl downloads nats chart to avoid fact that helm does not follow redirects.