### PR TITLE
[FIX] Fixes aws zone param

### DIFF
--- a/scripts/fruster-create-kube
+++ b/scripts/fruster-create-kube
@@ -277,7 +277,7 @@ Here are some commands that may come in handy:
 EOF
 }
 
-while getopts ":fvzhk:c:" opt; do
+while getopts ":fvhk:c:z:" opt; do
 	case $opt in    	
     k)
 		SSH_KEY="$OPTARG"


### PR DESCRIPTION
Fixes AWS zone param so i.e. `fruster-create-kube -z eu-north-1a foo` works.